### PR TITLE
Fix backend route closure

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -87,6 +87,7 @@ app.get("/api/results", (req, res) => {
 app.get("/api/state-results", (req, res) => {
   const data = fs.readFileSync("./data/state_results.json");
   res.json(JSON.parse(data));
+});
 
 app.listen(3001, () => {
   console.log("Backend server running on http://localhost:3001");


### PR DESCRIPTION
## Summary
- fix missing closing bracket on `/api/state-results` handler

## Testing
- `npm test` (fails: no test specified)
- `npm test` in `backend` (fails: no test specified)
- `npm test` in `frontend` (fails: missing script: test)
