### PR TITLE
Fix backend missing module issue

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,6 +1,7 @@
 # Backend API
 
-This Express server serves election results for the frontend. The main endpoints are:
+This Node.js server serves election results for the frontend without any external
+dependencies. The main endpoints are:
 
 - `GET /api/results` - returns the overall election results stored in `data/results.json`. Use the query parameter `state` to fetch data for a particular state, e.g. `/api/results?state=bayern`.
 - `POST /api/update-results` - downloads the latest election results for Germany and all states from the configured remote source and stores them in the `data` directory.

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,8 +1,19 @@
-const express = require("express");
-const cors = require("cors");
+const http = require("http");
+const url = require("url");
 const fs = require("fs");
 const path = require("path");
-const app = express();
+
+// Convenience function for sending JSON responses
+function sendJson(res, status, data) {
+  const body = JSON.stringify(data);
+  res.writeHead(status, {
+    "Content-Type": "application/json",
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "GET,POST,OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type",
+  });
+  res.end(body);
+}
 
 // List of German states used when fetching individual results
 const STATES = [
@@ -31,8 +42,6 @@ const STATE_URL_TEMPLATE =
   process.env.STATE_URL_TEMPLATE ||
   "https://example.com/election/{state}.json";
 
-app.use(cors());
-app.use(express.json());
 
 // Utility function to fetch JSON data from a URL
 async function fetchJson(url) {
@@ -69,25 +78,57 @@ async function updateResults() {
   }
 }
 
-// Return election results. Use `?state=` query parameter for state-specific data
-app.get("/api/results", (req, res) => {
-  const state = req.query.state;
-  const filePath = state
-    ? path.join(__dirname, "data", "states", `${state}.json`)
-    : path.join(__dirname, "data", "results.json");
+const server = http.createServer(async (req, res) => {
+  const parsed = url.parse(req.url, true);
 
-  if (!fs.existsSync(filePath)) {
-    return res.status(404).json({ error: "Results not found" });
+  if (req.method === "OPTIONS") {
+    // Handle CORS preflight
+    res.writeHead(204, {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET,POST,OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type",
+    });
+    res.end();
+    return;
   }
 
-  const data = fs.readFileSync(filePath);
-  res.json(JSON.parse(data));
+  if (req.method === "GET" && parsed.pathname === "/api/results") {
+    const state = parsed.query.state;
+    const filePath = state
+      ? path.join(__dirname, "data", "states", `${state}.json`)
+      : path.join(__dirname, "data", "results.json");
+
+    if (!fs.existsSync(filePath)) {
+      sendJson(res, 404, { error: "Results not found" });
+      return;
+    }
+
+    const data = fs.readFileSync(filePath);
+    sendJson(res, 200, JSON.parse(data));
+    return;
+  }
+
+  if (req.method === "GET" && parsed.pathname === "/api/state-results") {
+    const data = fs.readFileSync(path.join(__dirname, "data", "state_results.json"));
+    sendJson(res, 200, JSON.parse(data));
+    return;
+  }
+
+  if (req.method === "POST" && parsed.pathname === "/api/update-results") {
+    try {
+      await updateResults();
+      sendJson(res, 200, { success: true });
+    } catch (err) {
+      console.error(err);
+      sendJson(res, 500, { error: "Failed to update results" });
+    }
+    return;
+  }
+
+  // Not found
+  sendJson(res, 404, { error: "Not found" });
 });
 
-app.get("/api/state-results", (req, res) => {
-  const data = fs.readFileSync("./data/state_results.json");
-  res.json(JSON.parse(data));
-
-app.listen(3001, () => {
+server.listen(3001, () => {
   console.log("Backend server running on http://localhost:3001");
 });


### PR DESCRIPTION
## Summary
- drop Express dependency and use Node's built-in `http` server
- update backend README to mention the simplified HTTP server

## Testing
- `npm test` *(fails: no test specified)*
- `npm test` in `backend` *(fails: no test specified)*
- `npm test` in `frontend` *(fails: missing script)*